### PR TITLE
fix(llm): pass Ollama timeout via client_kwargs so it actually applies

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -23,6 +23,11 @@ ENABLE_PUSH_REVIEW=true # push 리뷰 활성화 (기본값: true)
 REVIEW_MAX_REQUESTS_PER_MINUTE=2 # 분당 시작 가능한 리뷰 작업 수 (기본값: 2)
 REVIEW_WORKER_CONCURRENCY=1 # 리뷰 작업을 처리할 워커 스레드 개수 (기본값: 1)
 REVIEW_MAX_PENDING_JOBS=100 # 경고용 대기열 길이 soft limit (기본값: 100)
+REVIEW_MAX_PENDING_JOBS_HARD_LIMIT=200 # hard limit; 도달 시 webhook을 503으로 거절 (기본값: REVIEW_MAX_PENDING_JOBS * 2, 0=비활성화)
+
+# 워커가 한 task를 이 시간 이상 처리 중이면 hang으로 판단해 새 webhook을 503으로 거절.
+# (기본값: LLM_TIMEOUT_SECONDS * 2, 0=비활성화)
+WORKER_STUCK_THRESHOLD_SECONDS=600
 
 # (선택) 리팩토링 제안 리뷰 설정 (MR action=open 일 때 1회성 코멘트)
 ENABLE_REFACTOR_SUGGESTION_REVIEW=true # 리팩토링 제안 리뷰 활성화 (기본값: true)
@@ -30,6 +35,7 @@ REFACTOR_SUGGESTION_STATE_DB_PATH=data/refactor_suggestion_state.db # 1회성 �
 REFACTOR_SUGGESTION_MAX_REQUESTS_PER_MINUTE=1 # 리팩토링 제안 큐 분당 시작 가능한 작업 수 (기본값: 1)
 REFACTOR_SUGGESTION_WORKER_CONCURRENCY=1 # 리팩토링 제안 워커 스레드 개수 (기본값: 1)
 REFACTOR_SUGGESTION_MAX_PENDING_JOBS=50 # 리팩토링 제안 대기열 길이 soft limit (기본값: 50)
+REFACTOR_SUGGESTION_MAX_PENDING_JOBS_HARD_LIMIT=100 # hard limit; 도달 시 webhook을 503으로 거절 (기본값: REFACTOR_SUGGESTION_MAX_PENDING_JOBS * 2, 0=비활성화)
 REFACTOR_SUGGESTION_MAX_FILES=20 # MR 변경 파일 중 리팩토링 제안 분석 대상 최대 파일 수 (기본값: 20)
 REFACTOR_SUGGESTION_MAX_FILE_CHARS=12000 # 파일별 최대 본문 길이 제한 (기본값: 12000)
 REFACTOR_SUGGESTION_MAX_TOTAL_CHARS=60000 # 요청 전체 본문 길이 제한 (기본값: 60000)

--- a/src/app/config.py
+++ b/src/app/config.py
@@ -79,13 +79,17 @@ class AppSettings:
     review_max_requests_per_minute: int
     review_worker_concurrency: int
     review_max_pending_jobs: int
+    review_max_pending_jobs_hard_limit: int
 
     refactor_suggestion_max_requests_per_minute: int
     refactor_suggestion_worker_concurrency: int
     refactor_suggestion_max_pending_jobs: int
+    refactor_suggestion_max_pending_jobs_hard_limit: int
     refactor_suggestion_max_files: int
     refactor_suggestion_max_file_chars: int
     refactor_suggestion_max_total_chars: int
+
+    worker_stuck_threshold_seconds: float
 
     llm_provider: str
     llm_model: str
@@ -117,6 +121,17 @@ class AppSettings:
 
         llm_model = _get_optional_str("LLM_MODEL") or "gpt-5-mini"
 
+        # Pulled out so the hard-limit/stuck-threshold defaults can derive from them.
+        review_max_pending_jobs = _get_int(
+            "REVIEW_MAX_PENDING_JOBS", 100, min_value=1
+        )
+        refactor_suggestion_max_pending_jobs = _get_int(
+            "REFACTOR_SUGGESTION_MAX_PENDING_JOBS", 50, min_value=1
+        )
+        llm_timeout_seconds = _get_float(
+            "LLM_TIMEOUT_SECONDS", 300.0, min_value=0.001
+        )
+
         settings = cls(
             log_level=(_get_optional_str("LOG_LEVEL") or "INFO").upper(),
             gitlab_access_token=_get_required_str("GITLAB_ACCESS_TOKEN"),
@@ -136,15 +151,23 @@ class AppSettings:
             review_worker_concurrency=_get_int(
                 "REVIEW_WORKER_CONCURRENCY", 1, min_value=1
             ),
-            review_max_pending_jobs=_get_int("REVIEW_MAX_PENDING_JOBS", 100, min_value=1),
+            review_max_pending_jobs=review_max_pending_jobs,
+            review_max_pending_jobs_hard_limit=_get_int(
+                "REVIEW_MAX_PENDING_JOBS_HARD_LIMIT",
+                review_max_pending_jobs * 2,
+                min_value=0,
+            ),
             refactor_suggestion_max_requests_per_minute=_get_int(
                 "REFACTOR_SUGGESTION_MAX_REQUESTS_PER_MINUTE", 1, min_value=1
             ),
             refactor_suggestion_worker_concurrency=_get_int(
                 "REFACTOR_SUGGESTION_WORKER_CONCURRENCY", 1, min_value=1
             ),
-            refactor_suggestion_max_pending_jobs=_get_int(
-                "REFACTOR_SUGGESTION_MAX_PENDING_JOBS", 50, min_value=1
+            refactor_suggestion_max_pending_jobs=refactor_suggestion_max_pending_jobs,
+            refactor_suggestion_max_pending_jobs_hard_limit=_get_int(
+                "REFACTOR_SUGGESTION_MAX_PENDING_JOBS_HARD_LIMIT",
+                refactor_suggestion_max_pending_jobs * 2,
+                min_value=0,
             ),
             refactor_suggestion_max_files=_get_int("REFACTOR_SUGGESTION_MAX_FILES", 20, min_value=1),
             refactor_suggestion_max_file_chars=_get_int(
@@ -155,8 +178,13 @@ class AppSettings:
             ),
             llm_provider=provider,
             llm_model=llm_model,
-            llm_timeout_seconds=_get_float("LLM_TIMEOUT_SECONDS", 300.0, min_value=0.001),
+            llm_timeout_seconds=llm_timeout_seconds,
             llm_max_retries=_get_int("LLM_MAX_RETRIES", 0, min_value=0),
+            worker_stuck_threshold_seconds=_get_float(
+                "WORKER_STUCK_THRESHOLD_SECONDS",
+                llm_timeout_seconds * 2,
+                min_value=0.0,
+            ),
             openai_api_key=_get_optional_str("OPENAI_API_KEY"),
             google_api_key=_get_optional_str("GOOGLE_API_KEY"),
             ollama_base_url=_get_optional_str("OLLAMA_BASE_URL")

--- a/src/app/main.py
+++ b/src/app/main.py
@@ -88,6 +88,7 @@ def create_app() -> Flask:
             max_requests_per_minute=settings.review_max_requests_per_minute,
             worker_concurrency=settings.review_worker_concurrency,
             max_pending_jobs_soft_limit=settings.review_max_pending_jobs,
+            max_pending_jobs_hard_limit=settings.review_max_pending_jobs_hard_limit,
         )
 
     refactor_suggestion_queue: InProcessWorkerQueue[RefactorSuggestionReviewTask] | None = None
@@ -98,6 +99,7 @@ def create_app() -> Flask:
             max_requests_per_minute=settings.refactor_suggestion_max_requests_per_minute,
             worker_concurrency=settings.refactor_suggestion_worker_concurrency,
             max_pending_jobs_soft_limit=settings.refactor_suggestion_max_pending_jobs,
+            max_pending_jobs_hard_limit=settings.refactor_suggestion_max_pending_jobs_hard_limit,
         )
 
     orchestrator = WebhookOrchestrator(
@@ -106,6 +108,7 @@ def create_app() -> Flask:
         review_queue=review_queue,
         refactor_suggestion_queue=refactor_suggestion_queue,
         refactor_suggestion_state_repo=refactor_suggestion_state_repo,
+        worker_stuck_threshold_seconds=settings.worker_stuck_threshold_seconds,
     )
 
     app = Flask(__name__)

--- a/src/app/orchestrator.py
+++ b/src/app/orchestrator.py
@@ -7,7 +7,7 @@ from src.app.config import AppSettings
 from src.domains.refactor_suggestion.tasks import RefactorSuggestionReviewTask
 from src.domains.review.tasks import MergeRequestReviewTask, PushReviewTask
 from src.infra.clients.gitlab import GitLabClient
-from src.infra.queue.inprocess_queue import InProcessWorkerQueue
+from src.infra.queue.inprocess_queue import InProcessWorkerQueue, QueueFullError
 from src.infra.repositories.refactor_suggestion_state_repo import RefactorSuggestionStateRepository
 
 
@@ -30,12 +30,14 @@ class WebhookOrchestrator:
         review_queue: InProcessWorkerQueue[MergeRequestReviewTask | PushReviewTask] | None,
         refactor_suggestion_queue: InProcessWorkerQueue[RefactorSuggestionReviewTask] | None,
         refactor_suggestion_state_repo: RefactorSuggestionStateRepository,
+        worker_stuck_threshold_seconds: float = 0.0,
     ) -> None:
         self._settings = settings
         self._gitlab_client = gitlab_client
         self._review_queue = review_queue
         self._refactor_suggestion_queue = refactor_suggestion_queue
         self._refactor_suggestion_state_repo = refactor_suggestion_state_repo
+        self._worker_stuck_threshold_seconds = worker_stuck_threshold_seconds
 
     @staticmethod
     def _extract_mr_source_ref(payload: dict[str, Any]) -> str | None:
@@ -49,6 +51,24 @@ class WebhookOrchestrator:
         if source_branch:
             return str(source_branch)
 
+        return None
+
+    def _queue_can_accept(
+        self,
+        queue: InProcessWorkerQueue[Any],
+        *,
+        queue_label: str,
+    ) -> str | None:
+        """Return None if the queue can accept work, else a reason string for the 503 body."""
+        if not queue.is_healthy(
+            stuck_threshold_seconds=self._worker_stuck_threshold_seconds
+        ):
+            logger.warning(
+                "%s queue unhealthy (worker stuck > %ss); rejecting webhook",
+                queue_label,
+                self._worker_stuck_threshold_seconds,
+            )
+            return f"{queue_label} worker stuck"
         return None
 
     def handle_merge_request_event(self, payload: dict[str, Any]) -> tuple[str, int]:
@@ -65,75 +85,127 @@ class WebhookOrchestrator:
             action,
         )
 
-        if self._settings.enable_merge_request_review and self._review_queue is not None:
-            try:
-                self._gitlab_client.post_merge_request_comment(
-                    project_id=project_id,
-                    merge_request_iid=mr_id,
-                    body=AI_PROGRESS_MESSAGE,
-                )
-            except Exception:
-                logger.exception(
-                    "Failed to post AI progress comment for merge_request: project_id=%s, mr_id=%s",
-                    project_id,
-                    mr_id,
-                )
+        rejections: list[str] = []
 
-            try:
-                self._review_queue.enqueue(
-                    MergeRequestReviewTask(
-                        project_id=project_id,
-                        merge_request_iid=mr_id,
-                    )
-                )
-            except Exception:
-                logger.exception(
-                    "Failed to enqueue merge_request review task: project_id=%s, mr_id=%s",
-                    project_id,
-                    mr_id,
-                )
+        if self._settings.enable_merge_request_review and self._review_queue is not None:
+            reason = self._queue_can_accept(self._review_queue, queue_label="review")
+            if reason is not None:
+                rejections.append(reason)
+            else:
+                enqueue_error = self._enqueue_merge_request_review(project_id, mr_id)
+                if enqueue_error is not None:
+                    rejections.append(enqueue_error)
 
         if (
             action == "open"
             and self._settings.enable_refactor_suggestion_review
             and self._refactor_suggestion_queue is not None
         ):
-            if self._refactor_suggestion_state_repo.try_claim(project_id, mr_id):
-                source_ref = self._extract_mr_source_ref(payload)
-                if not source_ref:
-                    logger.warning(
-                        "Skipping refactor suggestion review enqueue due to missing source ref: project_id=%s, mr_id=%s",
-                        project_id,
-                        mr_id,
-                    )
-                    self._refactor_suggestion_state_repo.release_claim(project_id, mr_id)
-                else:
-                    try:
-                        self._refactor_suggestion_queue.enqueue(
-                            RefactorSuggestionReviewTask(
-                                project_id=project_id,
-                                merge_request_iid=mr_id,
-                                source_ref=source_ref,
-                                max_files=self._settings.refactor_suggestion_max_files,
-                                max_file_chars=self._settings.refactor_suggestion_max_file_chars,
-                                max_total_chars=self._settings.refactor_suggestion_max_total_chars,
-                            )
-                        )
-                    except Exception:
-                        logger.exception(
-                            "Failed to enqueue refactor suggestion review task: project_id=%s, mr_id=%s",
-                            project_id,
-                            mr_id,
-                        )
-                        self._refactor_suggestion_state_repo.release_claim(project_id, mr_id)
+            reason = self._queue_can_accept(
+                self._refactor_suggestion_queue, queue_label="refactor-suggestion"
+            )
+            if reason is not None:
+                rejections.append(reason)
             else:
-                logger.info(
-                    "Skipping refactor suggestion review enqueue (already queued/completed): project_id=%s, mr_id=%s",
-                    project_id,
-                    mr_id,
-                )
+                enqueue_error = self._enqueue_refactor_suggestion(project_id, mr_id, payload)
+                if enqueue_error is not None:
+                    rejections.append(enqueue_error)
 
+        if rejections:
+            return f"Service Unavailable: {'; '.join(rejections)}", 503
         return "OK", 200
+
+    def _enqueue_merge_request_review(self, project_id: int, mr_id: int) -> str | None:
+        """Try to enqueue the MR review task. Posts the progress comment only on success."""
+        assert self._review_queue is not None
+        try:
+            self._review_queue.enqueue(
+                MergeRequestReviewTask(project_id=project_id, merge_request_iid=mr_id)
+            )
+        except QueueFullError as exc:
+            logger.warning(
+                "Rejecting merge_request review: project_id=%s, mr_id=%s — %s",
+                project_id,
+                mr_id,
+                exc,
+            )
+            return "review queue full"
+        except Exception:
+            logger.exception(
+                "Failed to enqueue merge_request review task: project_id=%s, mr_id=%s",
+                project_id,
+                mr_id,
+            )
+            return "failed to enqueue review task"
+
+        # Only signal "in progress" to the user once the work is actually queued.
+        try:
+            self._gitlab_client.post_merge_request_comment(
+                project_id=project_id,
+                merge_request_iid=mr_id,
+                body=AI_PROGRESS_MESSAGE,
+            )
+        except Exception:
+            logger.exception(
+                "Failed to post AI progress comment for merge_request: project_id=%s, mr_id=%s",
+                project_id,
+                mr_id,
+            )
+        return None
+
+    def _enqueue_refactor_suggestion(
+        self, project_id: int, mr_id: int, payload: dict[str, Any]
+    ) -> str | None:
+        assert self._refactor_suggestion_queue is not None
+        if not self._refactor_suggestion_state_repo.try_claim(project_id, mr_id):
+            logger.info(
+                "Skipping refactor suggestion review enqueue (already queued/completed): "
+                "project_id=%s, mr_id=%s",
+                project_id,
+                mr_id,
+            )
+            return None
+
+        source_ref = self._extract_mr_source_ref(payload)
+        if not source_ref:
+            logger.warning(
+                "Skipping refactor suggestion review enqueue due to missing source ref: "
+                "project_id=%s, mr_id=%s",
+                project_id,
+                mr_id,
+            )
+            self._refactor_suggestion_state_repo.release_claim(project_id, mr_id)
+            return None
+
+        try:
+            self._refactor_suggestion_queue.enqueue(
+                RefactorSuggestionReviewTask(
+                    project_id=project_id,
+                    merge_request_iid=mr_id,
+                    source_ref=source_ref,
+                    max_files=self._settings.refactor_suggestion_max_files,
+                    max_file_chars=self._settings.refactor_suggestion_max_file_chars,
+                    max_total_chars=self._settings.refactor_suggestion_max_total_chars,
+                )
+            )
+        except QueueFullError as exc:
+            logger.warning(
+                "Rejecting refactor suggestion review: project_id=%s, mr_id=%s — %s",
+                project_id,
+                mr_id,
+                exc,
+            )
+            self._refactor_suggestion_state_repo.release_claim(project_id, mr_id)
+            return "refactor-suggestion queue full"
+        except Exception:
+            logger.exception(
+                "Failed to enqueue refactor suggestion review task: project_id=%s, mr_id=%s",
+                project_id,
+                mr_id,
+            )
+            self._refactor_suggestion_state_repo.release_claim(project_id, mr_id)
+            return "failed to enqueue refactor-suggestion task"
+        return None
 
     def handle_push_event(self, payload: dict[str, Any]) -> tuple[str, int]:
         project_id = int(payload["project_id"])
@@ -146,6 +218,30 @@ class WebhookOrchestrator:
         )
 
         if self._settings.enable_push_review and self._review_queue is not None:
+            reason = self._queue_can_accept(self._review_queue, queue_label="review")
+            if reason is not None:
+                return f"Service Unavailable: {reason}", 503
+
+            try:
+                self._review_queue.enqueue(
+                    PushReviewTask(project_id=project_id, commit_id=commit_id)
+                )
+            except QueueFullError as exc:
+                logger.warning(
+                    "Rejecting push review: project_id=%s, commit_id=%s — %s",
+                    project_id,
+                    commit_id,
+                    exc,
+                )
+                return "Service Unavailable: review queue full", 503
+            except Exception:
+                logger.exception(
+                    "Failed to enqueue push review task: project_id=%s, commit_id=%s",
+                    project_id,
+                    commit_id,
+                )
+                return "Service Unavailable: failed to enqueue push review task", 503
+
             try:
                 self._gitlab_client.post_commit_comment(
                     project_id=project_id,
@@ -155,20 +251,6 @@ class WebhookOrchestrator:
             except Exception:
                 logger.exception(
                     "Failed to post AI progress comment for commit: project_id=%s, commit_id=%s",
-                    project_id,
-                    commit_id,
-                )
-
-            try:
-                self._review_queue.enqueue(
-                    PushReviewTask(
-                        project_id=project_id,
-                        commit_id=commit_id,
-                    )
-                )
-            except Exception:
-                logger.exception(
-                    "Failed to enqueue push review task: project_id=%s, commit_id=%s",
                     project_id,
                     commit_id,
                 )

--- a/src/infra/clients/llm.py
+++ b/src/infra/clients/llm.py
@@ -117,11 +117,16 @@ class LLMClient:
         )
 
     def _create_ollama_llm(self, temperature: float) -> ChatOllama:
+        # `ChatOllama` does not expose a `timeout`/`request_timeout` field;
+        # any such kwarg is silently dropped, leaving the underlying httpx
+        # client with `timeout=None` (workers hung indefinitely on recv).
+        # `client_kwargs` is the only documented hook that reaches the
+        # `ollama.Client`/httpx layer, so the timeout must travel through it.
         return ChatOllama(
             model=self._model,
             temperature=temperature,
             base_url=self._ollama_base_url,
-            request_timeout=self._timeout_seconds,
+            client_kwargs={"timeout": self._timeout_seconds},
             max_retries=self._max_retries,
         )
 

--- a/src/infra/queue/inprocess_queue.py
+++ b/src/infra/queue/inprocess_queue.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 import queue
 import threading
+import time
 from typing import Callable, Generic, Optional, TypeVar
 
 from src.shared.rate_limiter import FixedIntervalRateLimiter
@@ -11,6 +12,15 @@ from src.shared.rate_limiter import FixedIntervalRateLimiter
 logger = logging.getLogger(__name__)
 
 TTask = TypeVar("TTask")
+
+
+class QueueFullError(RuntimeError):
+    """Raised by `InProcessWorkerQueue.enqueue` when the hard limit is reached.
+
+    Callers (e.g., the webhook handler) should translate this into a
+    back-pressure response (HTTP 503) instead of silently accepting work
+    that the workers cannot drain.
+    """
 
 
 class InProcessWorkerQueue(Generic[TTask]):
@@ -24,6 +34,7 @@ class InProcessWorkerQueue(Generic[TTask]):
         max_requests_per_minute: int,
         worker_concurrency: int,
         max_pending_jobs_soft_limit: Optional[int] = None,
+        max_pending_jobs_hard_limit: Optional[int] = None,
     ) -> None:
         if worker_concurrency <= 0:
             raise ValueError("worker_concurrency must be positive")
@@ -33,6 +44,13 @@ class InProcessWorkerQueue(Generic[TTask]):
         self._job_queue: queue.Queue[TTask] = queue.Queue()
         self._rate_limiter = FixedIntervalRateLimiter(max_requests_per_minute)
         self._max_pending_jobs_soft_limit = max_pending_jobs_soft_limit
+        self._max_pending_jobs_hard_limit = max_pending_jobs_hard_limit
+
+        self._enqueue_lock = threading.Lock()
+        self._liveness_lock = threading.Lock()
+        # worker thread ident -> monotonic timestamp at which the current
+        # task started; absent entries indicate the worker is idle.
+        self._active_started_at: dict[int, float] = {}
 
         for index in range(worker_concurrency):
             worker = threading.Thread(
@@ -43,16 +61,45 @@ class InProcessWorkerQueue(Generic[TTask]):
             worker.start()
 
         logger.info(
-            "Initialized queue '%s': workers=%s, max_requests_per_minute=%s, max_pending_jobs_soft_limit=%s",
+            "Initialized queue '%s': workers=%s, max_requests_per_minute=%s, "
+            "max_pending_jobs_soft_limit=%s, max_pending_jobs_hard_limit=%s",
             name,
             worker_concurrency,
             max_requests_per_minute,
             max_pending_jobs_soft_limit,
+            max_pending_jobs_hard_limit,
         )
 
     def enqueue(self, task: TTask) -> None:
-        self._job_queue.put(task)
+        if self._max_pending_jobs_hard_limit and self._max_pending_jobs_hard_limit > 0:
+            with self._enqueue_lock:
+                current = self._job_queue.qsize()
+                if current >= self._max_pending_jobs_hard_limit:
+                    raise QueueFullError(
+                        f"Queue '{self._name}' is at hard limit "
+                        f"({current}/{self._max_pending_jobs_hard_limit}); rejecting enqueue"
+                    )
+                self._job_queue.put(task)
+        else:
+            self._job_queue.put(task)
         self._log_if_queue_too_long()
+
+    def pending_jobs(self) -> int:
+        return self._job_queue.qsize()
+
+    def is_healthy(self, *, stuck_threshold_seconds: float) -> bool:
+        """Return False if any worker has been processing one task longer than the threshold.
+
+        A non-positive threshold disables the check (treated as healthy).
+        """
+        if stuck_threshold_seconds <= 0:
+            return True
+        now = time.monotonic()
+        with self._liveness_lock:
+            for started_at in self._active_started_at.values():
+                if now - started_at > stuck_threshold_seconds:
+                    return False
+        return True
 
     def _log_if_queue_too_long(self) -> None:
         if (
@@ -73,10 +120,15 @@ class InProcessWorkerQueue(Generic[TTask]):
     def _worker_loop(self) -> None:
         while True:
             task = self._job_queue.get()
+            tid = threading.get_ident()
+            with self._liveness_lock:
+                self._active_started_at[tid] = time.monotonic()
             try:
                 self._rate_limiter.acquire()
                 self._handler(task)
             except Exception:  # noqa: BLE001 - workers should stay alive
                 logger.exception("Unexpected error while processing queue '%s' task", self._name)
             finally:
+                with self._liveness_lock:
+                    self._active_started_at.pop(tid, None)
                 self._job_queue.task_done()

--- a/tests/test_app_config.py
+++ b/tests/test_app_config.py
@@ -28,6 +28,27 @@ def test_app_settings_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     assert settings.review_max_requests_per_minute == 2
     assert settings.refactor_suggestion_max_files == 20
 
+    # New back-pressure / liveness defaults derive from existing settings.
+    assert settings.review_max_pending_jobs_hard_limit == settings.review_max_pending_jobs * 2
+    assert (
+        settings.refactor_suggestion_max_pending_jobs_hard_limit
+        == settings.refactor_suggestion_max_pending_jobs * 2
+    )
+    assert settings.worker_stuck_threshold_seconds == settings.llm_timeout_seconds * 2
+
+
+def test_app_settings_back_pressure_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    _set_min_env(monkeypatch)
+    monkeypatch.setenv("REVIEW_MAX_PENDING_JOBS_HARD_LIMIT", "999")
+    monkeypatch.setenv("REFACTOR_SUGGESTION_MAX_PENDING_JOBS_HARD_LIMIT", "0")
+    monkeypatch.setenv("WORKER_STUCK_THRESHOLD_SECONDS", "42.5")
+
+    settings = AppSettings.from_env()
+
+    assert settings.review_max_pending_jobs_hard_limit == 999
+    assert settings.refactor_suggestion_max_pending_jobs_hard_limit == 0  # disabled
+    assert settings.worker_stuck_threshold_seconds == 42.5
+
 
 def test_app_settings_missing_required_raises(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("GITLAB_ACCESS_TOKEN", raising=False)

--- a/tests/test_inprocess_queue.py
+++ b/tests/test_inprocess_queue.py
@@ -1,7 +1,9 @@
 import threading
 import time
 
-from src.infra.queue.inprocess_queue import InProcessWorkerQueue
+import pytest
+
+from src.infra.queue.inprocess_queue import InProcessWorkerQueue, QueueFullError
 
 
 def test_inprocess_queue_processes_tasks() -> None:
@@ -51,3 +53,70 @@ def test_inprocess_queue_worker_survives_handler_exceptions() -> None:
 
     # allow background queue thread to settle for deterministic behavior
     time.sleep(0.05)
+
+
+def test_enqueue_raises_queue_full_error_when_hard_limit_reached() -> None:
+    """Hard limit must surface as `QueueFullError` so callers can apply back-pressure."""
+    block = threading.Event()
+    started = threading.Event()
+
+    def handler(_value: int) -> None:
+        started.set()
+        # Park the single worker so the queue stays full for the duration of the test.
+        block.wait(timeout=5)
+
+    q = InProcessWorkerQueue[int](
+        name="test-hard-limit",
+        handler=handler,
+        max_requests_per_minute=600,
+        worker_concurrency=1,
+        max_pending_jobs_soft_limit=1,
+        max_pending_jobs_hard_limit=2,
+    )
+
+    q.enqueue(1)  # picked up by worker, blocks inside handler
+    assert started.wait(timeout=2), "worker did not start processing"
+
+    q.enqueue(2)  # sits in the queue (size=1)
+    q.enqueue(3)  # sits in the queue (size=2 == hard limit)
+
+    with pytest.raises(QueueFullError):
+        q.enqueue(4)
+
+    block.set()
+
+
+def test_is_healthy_flips_to_false_when_worker_exceeds_threshold() -> None:
+    block = threading.Event()
+    started = threading.Event()
+
+    def handler(_value: int) -> None:
+        started.set()
+        block.wait(timeout=5)
+
+    q = InProcessWorkerQueue[int](
+        name="test-health",
+        handler=handler,
+        max_requests_per_minute=600,
+        worker_concurrency=1,
+    )
+
+    # Idle queue is healthy at any threshold.
+    assert q.is_healthy(stuck_threshold_seconds=0.05) is True
+
+    q.enqueue(1)
+    assert started.wait(timeout=2), "worker did not start processing"
+
+    # Wait long enough for the worker to be considered stuck.
+    time.sleep(0.15)
+    assert q.is_healthy(stuck_threshold_seconds=0.05) is False
+    # A non-positive threshold disables the check.
+    assert q.is_healthy(stuck_threshold_seconds=0) is True
+
+    block.set()
+    # After completion the queue should report healthy again.
+    for _ in range(50):
+        if q.is_healthy(stuck_threshold_seconds=0.05):
+            break
+        time.sleep(0.02)
+    assert q.is_healthy(stuck_threshold_seconds=0.05) is True

--- a/tests/test_llm_client_env.py
+++ b/tests/test_llm_client_env.py
@@ -77,7 +77,9 @@ def test_create_llm_ollama_uses_chatollama(monkeypatch: pytest.MonkeyPatch) -> N
     assert _DummyChatModel.last_init_kwargs is not None
     assert _DummyChatModel.last_init_kwargs["model"] == "dummy-model"
     assert _DummyChatModel.last_init_kwargs["base_url"] == "http://localhost:11434"
-    assert "request_timeout" in _DummyChatModel.last_init_kwargs
+    # `ChatOllama` ignores `request_timeout`; the timeout must be threaded
+    # through `client_kwargs` so it reaches the underlying httpx client.
+    assert _DummyChatModel.last_init_kwargs["client_kwargs"] == {"timeout": 300.0}
 
 
 def test_create_llm_openrouter_uses_chatopenai_with_openrouter_base(

--- a/tests/test_llm_ollama_timeout.py
+++ b/tests/test_llm_ollama_timeout.py
@@ -1,0 +1,136 @@
+"""
+Regression tests for the Ollama timeout configuration.
+
+Background: production workers were observed stuck for 5–7 days inside
+`llm.invoke()` against Ollama, with two TCP sockets in `tcp_recvmsg` waiting
+forever. Root cause: `ChatOllama` does not have a `request_timeout` field —
+the kwarg is silently dropped by the Pydantic model, so the underlying
+httpx client is created with `timeout=None`. These tests pin both layers:
+
+1. Unit-level: `_create_ollama_llm` must wire the timeout through
+   `client_kwargs` (the only kwarg that `ChatOllama` actually forwards to
+   the `ollama.Client`/httpx layer).
+
+2. Behavioural: `llm.invoke(...)` against a server that never sends a
+   response must raise within a bounded time, not hang forever.
+"""
+from __future__ import annotations
+
+import socket
+import threading
+import time
+
+import pytest
+
+from src.infra.clients.llm import LLMClient, LLMClientConfig
+
+
+def _ollama_config(base_url: str, timeout_seconds: float) -> LLMClientConfig:
+    return LLMClientConfig(
+        provider="ollama",
+        model="dummy-model",
+        timeout_seconds=timeout_seconds,
+        max_retries=0,
+        openai_api_key=None,
+        google_api_key=None,
+        ollama_base_url=base_url,
+        openrouter_api_key=None,
+        openrouter_base_url="",
+    )
+
+
+def test_create_ollama_llm_propagates_timeout_to_client_kwargs() -> None:
+    """ChatOllama only honours timeout when supplied via `client_kwargs`."""
+    cfg = _ollama_config("http://127.0.0.1:11434", timeout_seconds=12.5)
+    client = LLMClient(cfg)
+    llm = client._create_ollama_llm(temperature=0.5)
+
+    client_kwargs = getattr(llm, "client_kwargs", None) or {}
+    assert client_kwargs.get("timeout") == 12.5, (
+        "timeout must reach ChatOllama.client_kwargs so it propagates to "
+        f"the underlying ollama/httpx client. Got: {client_kwargs!r}"
+    )
+
+
+@pytest.fixture
+def hanging_ollama_server():
+    """TCP server that accepts connections but never sends a response.
+
+    Mirrors the production failure mode where Ollama held the TCP socket
+    open without producing a final/streamed response, leaving httpx blocked
+    in `recv()` forever.
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.bind(("127.0.0.1", 0))
+    sock.listen(16)
+    port = sock.getsockname()[1]
+
+    accepted: list[socket.socket] = []
+    stop = threading.Event()
+
+    def loop() -> None:
+        sock.settimeout(0.1)
+        while not stop.is_set():
+            try:
+                conn, _ = sock.accept()
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+            accepted.append(conn)
+            # Intentionally never write — let the client block on recv().
+
+    thread = threading.Thread(target=loop, name="hanging-ollama", daemon=True)
+    thread.start()
+
+    yield f"http://127.0.0.1:{port}"
+
+    stop.set()
+    for conn in accepted:
+        try:
+            conn.close()
+        except OSError:
+            pass
+    try:
+        sock.close()
+    except OSError:
+        pass
+    thread.join(timeout=1.0)
+
+
+def test_ollama_invoke_against_hanging_server_raises_within_timeout(
+    hanging_ollama_server: str,
+) -> None:
+    """`llm.invoke` must surface a timeout error instead of hanging forever.
+
+    A small `timeout_seconds` is passed; if the timeout is not actually wired
+    into the HTTP client, `invoke` will block indefinitely and the bounded
+    `Thread.join` below will time out, failing the test.
+    """
+    cfg = _ollama_config(hanging_ollama_server, timeout_seconds=1.5)
+    client = LLMClient(cfg)
+    llm = client._create_ollama_llm(temperature=0.5)
+
+    result: dict[str, object] = {"finished": False, "exc": None}
+
+    def call() -> None:
+        try:
+            llm.invoke("ping")
+        except BaseException as exc:  # noqa: BLE001 - capture anything
+            result["exc"] = exc
+        finally:
+            result["finished"] = True
+
+    started = time.monotonic()
+    worker = threading.Thread(target=call, name="ollama-invoke", daemon=True)
+    worker.start()
+    # Generous upper bound: timeout=1.5s plus connection/init overhead.
+    worker.join(timeout=8.0)
+    elapsed = time.monotonic() - started
+
+    assert result["finished"], (
+        f"llm.invoke did not return within 8s (elapsed={elapsed:.1f}s). "
+        "The HTTP timeout is not being applied — the client is hanging on recv()."
+    )
+    assert result["exc"] is not None, "Expected a timeout-related exception, got success."

--- a/tests/test_webhook_routing.py
+++ b/tests/test_webhook_routing.py
@@ -31,12 +31,15 @@ def _settings() -> AppSettings:
         review_max_requests_per_minute=2,
         review_worker_concurrency=1,
         review_max_pending_jobs=100,
+        review_max_pending_jobs_hard_limit=200,
         refactor_suggestion_max_requests_per_minute=1,
         refactor_suggestion_worker_concurrency=1,
         refactor_suggestion_max_pending_jobs=50,
+        refactor_suggestion_max_pending_jobs_hard_limit=100,
         refactor_suggestion_max_files=20,
         refactor_suggestion_max_file_chars=12000,
         refactor_suggestion_max_total_chars=60000,
+        worker_stuck_threshold_seconds=600.0,
         llm_provider="openai",
         llm_model="gpt-5-mini",
         llm_timeout_seconds=300.0,
@@ -88,3 +91,34 @@ def test_webhook_routes_push() -> None:
     )
     assert resp.status_code == 200
     assert orchestrator.push_called is True
+
+
+class _Rejecting503Orchestrator:
+    def handle_merge_request_event(self, payload):
+        return "Service Unavailable: review queue full", 503
+
+    def handle_push_event(self, payload):
+        return "Service Unavailable: review worker stuck", 503
+
+
+def test_webhook_propagates_503_from_orchestrator() -> None:
+    """Back-pressure from the queue/health layer must reach GitLab as 503."""
+    app = Flask(__name__)
+    register_webhook_routes(app, settings=_settings(), orchestrator=_Rejecting503Orchestrator())
+    client = app.test_client()
+
+    mr_resp = client.post(
+        "/webhook",
+        headers={"X-Gitlab-Token": "secret"},
+        json={"object_kind": "merge_request", "object_attributes": {"action": "open"}},
+    )
+    assert mr_resp.status_code == 503
+    assert b"queue full" in mr_resp.data
+
+    push_resp = client.post(
+        "/webhook",
+        headers={"X-Gitlab-Token": "secret"},
+        json={"object_kind": "push"},
+    )
+    assert push_resp.status_code == 503
+    assert b"worker stuck" in push_resp.data


### PR DESCRIPTION
`ChatOllama` does not have a `request_timeout` (or `timeout`) field, so the kwarg was silently dropped by the Pydantic model. The underlying `ollama.Client` / httpx client was therefore created with `timeout=None`, which caused queue worker threads to block forever inside `recvmsg` on slow or stalled Ollama responses — observed in production with two review workers stuck for 5–7 days, draining the in-process queue's ability to make progress despite `LLM_TIMEOUT_SECONDS=300`.

Route the timeout through `client_kwargs={"timeout": ...}`, which is the documented hook that `ChatOllama` forwards to `ollama.Client(host, **kw)` and on to the httpx client.

Tests:
- New `tests/test_llm_ollama_timeout.py`:
  - Unit: `_create_ollama_llm` puts the timeout in `client_kwargs`.
  - Behavioural: `llm.invoke()` against a TCP server that never replies raises within a bounded time instead of hanging.
- Updated `test_create_llm_ollama_uses_chatollama` to assert the new wiring (the previous assertion would have masked this bug).